### PR TITLE
Add 'src/main/libs' dir to gradle.build

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,7 +1,7 @@
 repositories {
     jcenter()
     flatDir {
-        dirs 'libs'
+        dirs 'libs', 'src/main/libs'
     }
 }
 


### PR DESCRIPTION
Looks like in [Cordova Android 7.0.0][release], directories
have changed, which causes a problem for gradle when looking
for local dependencies.

This commit adds another directory (src/main/libs) to the
gradle.build. This is the directory that the plugin.xml file
copies the spotify-sdk.aar to. But the current version build
is looking for it in the 'libs' directory. To keep it
backward compatible, we just add another directory to look
for this dependency.

[release]: https://cordova.apache.org/announcements/2017/12/04/cordova-android-7.0.0.html

resolves: #38

[See also](https://github.com/Festify/cordova-spotify/issues/38#issuecomment-354495339)